### PR TITLE
Fix bugs and replace deprecated distutils module

### DIFF
--- a/generate_me.py
+++ b/generate_me.py
@@ -1,7 +1,7 @@
 from markdown2 import Markdown, UnicodeWithAttrs
 import os
 from jinja2 import Environment, FileSystemLoader
-from distutils.dir_util import copy_tree
+import shutil
 import datetime
 import email.utils
 from helper_libs.image_utils import ImageText
@@ -67,7 +67,7 @@ tag_post_dict = {}
 index_pages_to_generate = []
 
 create_folder_ifnot(out_folder)
-copy_tree(resources_folder, out_folder)
+shutil.copytree(resources_folder, out_folder, dirs_exist_ok=True)
 
 first_run = True
 for x in os.walk(src_folder):
@@ -294,4 +294,4 @@ with open(os.path.join(out_folder, "feed.rss"), "w") as f:
         )
     )
 
-copy_tree(resources_folder, out_folder)
+shutil.copytree(resources_folder, out_folder, dirs_exist_ok=True)

--- a/toot_me.py
+++ b/toot_me.py
@@ -34,7 +34,7 @@ class TootContent:
 		self.text = text
 		self.images = []
 		self.links = []
-		self.image_count = len(images)
+		self.image_count = len(self.images)
 
 	def __str__(self):
 		toot_text = self.text
@@ -153,7 +153,7 @@ for line in markdown_content.split("\n"):
 				continue
 			if len(re.findall(markdown_image,line)) > 0:
 				for image_link in re.findall(markdown_links, line):
-					image_link.append(image_link[1])
+					image_links.append(image_link[1])
 					# not handled yet
 				line = re.sub(markdown_image,"",line)
 			if len(re.findall(markdown_links,line)) > 0:


### PR DESCRIPTION
## Summary

This PR fixes several bugs and removes deprecated module usage:

- **Replace deprecated `distutils.dir_util.copy_tree` with `shutil.copytree`**: The `distutils` module was deprecated in Python 3.10 and removed in Python 3.12. This change ensures compatibility with modern Python versions.

- **Fix `NameError` in `TootContent.__init__`**: The constructor was referencing an undefined global variable `images` instead of `self.images`. This would cause a runtime error when instantiating a `TootContent` object.

- **Fix incorrect append in `toot_me.py`**: Line 156 was calling `image_link.append()` on the loop variable (a tuple from regex match) instead of `image_links.append()` to add to the list. This would cause an `AttributeError` since tuples don't have an `append` method.

## Changes

- `generate_me.py`: Replace `from distutils.dir_util import copy_tree` with `import shutil` and update both calls to use `shutil.copytree(src, dst, dirs_exist_ok=True)`
- `toot_me.py`: Fix `self.image_count = len(images)` to `self.image_count = len(self.images)` 
- `toot_me.py`: Fix `image_link.append(image_link[1])` to `image_links.append(image_link[1])`

## Test plan

- [ ] Run `python3 -m py_compile generate_me.py` to verify syntax
- [ ] Run `python3 -m py_compile toot_me.py` to verify syntax
- [ ] Run `python3 generate_me.py` to verify site generation works
- [ ] Verify generated site in `docs/` folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file directory operations to better handle existing destination directories.
  * Fixed image extraction and counting in content parsing workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->