### PR TITLE
Update copyright year to 2026

### DIFF
--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -12,7 +12,7 @@
             <li><a class="sidebar-nav-item" href="/feed.rss">RSS Feed</a></li>
             <li><a class="sidebar-nav-item" href="/colophon/">colophon</a></li>
         </ul>
-        <div class="copyright"><p>&copy; 2019-2025. Navan Chauhan <br> <a href="/feed.rss">RSS</a></p></div>
+        <div class="copyright"><p>&copy; 2019-2026. Navan Chauhan <br> <a href="/feed.rss">RSS</a></p></div>
     </div>
 </div>
 


### PR DESCRIPTION
Updates the site footer copyright range from 2019-2025 to 2019-2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year to 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->