### PR TITLE
Remove front-page post summaries

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
 <ul>
 {% for post in posts[:5] %}
 	<li><a href="{{post.link}}">{{ post.title }}</a>
-	{% if post.description or (post.date and post.date != "2003-12-21 00:00") or post.tags %}
+	{% if (post.date and post.date != "2003-12-21 00:00") or post.tags %}
             {{ render_post_details(post) }}
     {% endif %}
     </li>

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,8 +1,5 @@
 {% macro render_post_details(post) %}
     <ul>
-        {% if post.description %}
-            <li>{{ post.description }}</li>
-        {% endif %}
         {% if post.date and post.date != "2003-12-21 00:00" %}
             <li>Published On: {{ post.date }}</li>
         {% endif %}


### PR DESCRIPTION
Remove post descriptions from the front page recent-post list while preserving date and tag metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified post details rendering to only display when posts contain a qualifying date or tags
  * Post descriptions are no longer included in rendered post details output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->